### PR TITLE
Removed Foundry V10 depreciation warnings

### DIFF
--- a/module.json
+++ b/module.json
@@ -1,11 +1,18 @@
 {
+	"id": "popout-resizer",
 	"name": "popout-resizer",
 	"title": "Popout Resizer",
 	"description": "A simple module that allows you to resize the side toolbar popouts such as the combat tracker, scenes, actors and compendiums.",
 	"version": "1.4.2",
 	"author": "cardagon",
+    "authors": [{ "name": "cardagon" }],
 	"minimumCoreVersion": "0.6.0",
 	"compatibleCoreVersion": "9",
+	"compatibility": {
+	    "minimum": 9,
+    	"verified": "10.291",
+    	"maximum": "10"
+	},
 	"esmodules": [
 		"./main.js"
 	],


### PR DESCRIPTION
This module is working like a charm with foundry v10, too.

I've added "id" and "authors" to module.json in order to stop foundry v10 from moaning about dependency warnings.
Old "name" and "author" is still there, so it will work with older foundry versions, too.

Relating to issue  #11