### PR TITLE
Update to Foundry V13

### DIFF
--- a/main.js
+++ b/main.js
@@ -3,7 +3,6 @@ import * as PopoutResizer from './modules/popout-resizer.js';
 
 Hooks.on("init", async () => {
     Hooks.on('renderApplicationV2', (app, html, data, flags) => {
-        console.log('in renderApplicationV2! got:', app, html, data, flags);
         PopoutResizer.PopoutResizer.sidebarTabRendered(app, $(html), data);
     });
 

--- a/main.js
+++ b/main.js
@@ -2,13 +2,10 @@ import * as PopoutSetings from './modules/register-settings.js';
 import * as PopoutResizer from './modules/popout-resizer.js';
 
 Hooks.on("init", async () => {
-    // Hook into all render sidebar tabs this will fire for every sidebar tab
-    Hooks.on("renderSidebarTab", PopoutResizer.PopoutResizer.sidebarTabRendered);
-
-    // Handle combat tracker for PF2E
-    if(game.system.id === 'pf2e') {
-        Hooks.on('renderCombatTracker', PopoutResizer.PopoutResizer.sidebarTabRendered);
-    }
+    Hooks.on('renderApplicationV2', (app, html, data, flags) => {
+        console.log('in renderApplicationV2! got:', app, html, data, flags);
+        PopoutResizer.PopoutResizer.sidebarTabRendered(app, $(html), data);
+    });
 
     PopoutSetings.registerSettings();
     PopoutSetings.initializeSettings();

--- a/module.json
+++ b/module.json
@@ -26,7 +26,7 @@
     }
   ],
   "url": "https://github.com/Cardagon/popout-resizer",
-  "download": "https://github.com/Cardagon/popout-resizer/releases/download/v1.5.1/v1.5.1.zip",
+  "download": "https://github.com/Cardagon/popout-resizer/releases/download/v1.6.0/v1.6.0.zip",
   "manifest": "https://raw.githubusercontent.com/Cardagon/popout-resizer/master/module.json",
   "languages": [
     {

--- a/module.json
+++ b/module.json
@@ -1,35 +1,46 @@
 {
-	"id": "popout-resizer",
-	"name": "popout-resizer",
-	"title": "Popout Resizer",
-	"description": "A simple module that allows you to resize the side toolbar popouts such as the combat tracker, scenes, actors and compendiums.",
-	"version": "1.5.1",
-	"author": "cardagon",
-    "authors": [{ "name": "cardagon" }],
-	"compatibility": {
-	    "minimum": 9,
-    	"verified": "11.306",
-    	"maximum": "11"
-	},
-	"esmodules": [
-		"./main.js"
-	],
-	"styles": [
-		"./popout-resizer.css"
-	],
-	"url": "https://github.com/Cardagon/popout-resizer",
-	"download": "https://github.com/Cardagon/popout-resizer/releases/download/v1.5.1/v1.5.1.zip",
-	"manifest": "https://raw.githubusercontent.com/Cardagon/popout-resizer/master/module.json",
-	"languages": [
-		{
-			"lang": "en",
-			"name": "English",
-			"path": "lang/en.json"
-		},
-		{
-			"lang": "de",
-			"name": "Deutsch",
-			"path": "lang/de.json"
-		}
-	]
+  "id": "popout-resizer",
+  "title": "Popout Resizer",
+  "description": "A simple module that allows you to resize the side toolbar popouts such as the combat tracker, scenes, actors and compendiums.",
+  "version": "1.6.0",
+  "authors": [
+    {
+      "name": "cardagon",
+      "flags": {}
+    },
+    {
+      "name": "iconmaster",
+      "flags": {}
+    }
+  ],
+  "compatibility": {
+    "minimum": "13",
+    "verified": "13.347"
+  },
+  "esmodules": [
+    "main.js"
+  ],
+  "styles": [
+    {
+      "src": "popout-resizer.css"
+    }
+  ],
+  "url": "https://github.com/Cardagon/popout-resizer",
+  "download": "https://github.com/Cardagon/popout-resizer/releases/download/v1.5.1/v1.5.1.zip",
+  "manifest": "https://raw.githubusercontent.com/Cardagon/popout-resizer/master/module.json",
+  "languages": [
+    {
+      "lang": "en",
+      "name": "English",
+      "path": "lang/en.json",
+      "flags": {}
+    },
+    {
+      "lang": "de",
+      "name": "Deutsch",
+      "path": "lang/de.json",
+      "flags": {}
+    }
+  ],
+  "flags": {}
 }

--- a/modules/popout-resizer.js
+++ b/modules/popout-resizer.js
@@ -11,20 +11,16 @@ export class PopoutResizer {
     static sidebarTabRendered(obj, html, data) {
 
         // Only handle this event if the obj in question is a popout
-        if(obj.options.popOut){
+        if(html.hasClass("sidebar-popout")){
 
             // Get existing size data
-            let resizeData = PopoutResizer.popoutResizerSettings[obj.tabName];
-            let resizeHandled = obj.resizeHandled;
-
-            if(!resizeHandled){
-                var resizablePopout = new ResizablePopout(obj, html);
-            }
+            let resizeData = PopoutResizer.popoutResizerSettings[obj.title];
+            var resizablePopout = new ResizablePopout(obj, html);
 
             // If we are supposed to remember size or if the popout is already open
-            if(resizeData && (resizeHandled || PopoutResizer.rememberSize)) {
+            if(resizeData && PopoutResizer.rememberSize) {
                 obj.setPosition({left: resizeData.left, top: resizeData.top, width: resizeData.width, height: resizeData.height});
-                if(obj.tabName === 'combat') {
+                if(obj.title === 'combat') {
                     obj.scrollToTurn();
                 }
             } else {
@@ -45,7 +41,7 @@ class ResizablePopout {
         const header = html.find('header')[0];
         header.addEventListener('pointerdown', e => this._onDragMouseDown(e), false);
         
-        this.dragHandler = new Draggable(app, html, header, true);
+        this.dragHandler = new foundry.applications.ux.Draggable(app, html, header, true);
         
         this.handle = this.html.find('.window-resizable-handle')[0];
         if(this.handle) {
@@ -53,9 +49,6 @@ class ResizablePopout {
         } else {
             console.error(game.i18n.format('POPOUTRESIZER.NoResizeHandlerError', {appId : this.app.id}));
         }
-
-        this.app.resizeHandled = true;
-        this.app.options.height = null;
     }
 
     _onDragMouseDown(event) {
@@ -72,7 +65,7 @@ class ResizablePopout {
             left: this.app.position.left
         };
 
-        PopoutResizer.popoutResizerSettings[this.app.tabName] = resizeData;
+        PopoutResizer.popoutResizerSettings[this.app.title] = resizeData;
         game.settings.set('popout-resizer', 'popout-resizer-settings', PopoutResizer.popoutResizerSettings);
     }
 
@@ -92,7 +85,7 @@ class ResizablePopout {
             left: this.app.position.left
         };
 
-        PopoutResizer.popoutResizerSettings[this.app.tabName] = resizeData;
+        PopoutResizer.popoutResizerSettings[this.app.title] = resizeData;
         game.settings.set('popout-resizer', 'popout-resizer-settings', PopoutResizer.popoutResizerSettings);
     }
 }

--- a/popout-resizer.css
+++ b/popout-resizer.css
@@ -1,3 +1,8 @@
 .app.sidebar-popout {
     min-height: 200px;
 }
+
+.sidebar-popout .window-resizable-handle {
+    display: grid;
+    justify-items: end;
+}


### PR DESCRIPTION
- No more nice and easy `popOut` option to detect if we're a popout. Now we have to inspect the CSS classes on the main element. This might break with custom theming? It's unlikely but possible.
- No more need to special-case certain popouts (tested with PF2E).
- I did not change `module.json` (except to bump version numbers and add my name). Foundry did the rest of the changes when migrating to v13.
- Applications are now re-used between openings, so we can't be storing data there to see if we need to re-apply HTML. On the bright side, that means we only have to ever apply our HTML once, so there's no need for the system in general!
- No more `tabName`, but we do have `title`. Should work similarly.
- Added some CSS to make sure the resizer dragger handle thingy looks nice. For some reason it sits in the wrong corner in V13 by default.