### PR TITLE
Verify Popout Resizer on Foundry V14

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,41 +1,34 @@
+name: Release
+
 on:
   push:
-    # Sequence of patterns matched against refs/tags
     tags:
-      - 'v*'
-
-name: Upload Release Asset
+      - "v*"
 
 jobs:
-  build:
-    name: Upload Release Asset
+  release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Get version
-        id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/*/}
-      - name: Zip files
+        uses: actions/checkout@v4
+
+      - name: Build module zip
         run: |
-          zip -r ${{ steps.get_version.outputs.VERSION }}.zip *
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
+          zip -r module.zip . \
+            -x ".git/*" \
+            -x ".github/*" \
+            -x ".gitignore" \
+            -x "module.zip" \
+            -x "*.zip"
+
+      - name: Create GitHub release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          draft: false
-          prerelease: false
-      - name: Upload Release Asset
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./${{ steps.get_version.outputs.VERSION }}.zip
-          asset_name: ${{ steps.get_version.outputs.VERSION }}.zip
-          asset_content_type: application/zip
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${GITHUB_REF_NAME}" \
+            --title "${GITHUB_REF_NAME}" \
+            --notes "Popout Resizer ${GITHUB_REF_NAME}" \
+            module.json module.zip

--- a/README.md
+++ b/README.md
@@ -4,10 +4,18 @@ Popout Resizer lets you resize Foundry VTT sidebar popout windows, including com
 
 ## Install
 
-Install Popout Resizer from Foundry's **Add-on Modules** screen with this manifest URL:
+In Foundry, open **Add-on Modules > Install Module**, paste a manifest URL into **Manifest URL**, and install.
+
+Official upstream channel:
 
 ```text
 https://raw.githubusercontent.com/Cardagon/popout-resizer/master/module.json
+```
+
+Spencer's Foundry V14 compatibility build:
+
+```text
+https://github.com/SpencerZPoole/popout-resizer/releases/latest/download/module.json
 ```
 
 After installation, enable **Popout Resizer** in your world's **Manage Modules** menu.

--- a/README.md
+++ b/README.md
@@ -1,80 +1,44 @@
 # Popout Resizer
 
-![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/cardagon/popout-resizer?style=for-the-badge)  ![GitHub Releases](https://img.shields.io/github/downloads/cardagon/popout-resizer/latest/total?style=for-the-badge) ![GitHub All Releases](https://img.shields.io/github/downloads/cardagon/popout-resizer/total?style=for-the-badge&label=Downloads+total)
+Popout Resizer lets you resize Foundry VTT sidebar popout windows, including combat, scenes, actors, journals, items, roll tables, playlists, compendiums, and settings.
 
-A [FoundryVTT](http://foundryvtt.com/) module to give the users the ability to resize their pop-out windows from the side toolbar.
+## Install
 
-# Installation
+Install Popout Resizer from Foundry's **Add-on Modules** screen with this manifest URL:
 
-## Recommended
+```text
+https://raw.githubusercontent.com/Cardagon/popout-resizer/master/module.json
+```
 
-1. Go to Foundry's Setup screen
-1. Go to the "Add-On Modules" tab
-1. Press "Install Module"
-1. Paste `https://raw.githubusercontent.com/Cardagon/popout-resizer/master/module.json` into the text field
-1. Press "Install"
+After installation, enable **Popout Resizer** in your world's **Manage Modules** menu.
 
-# Features
-- All popouts from the side bar are resizable (minimum height and width is 200 px)
-    - Combat Tracker
-    - Scenes
-    - Actors
-    - Journals
-    - Items
-    - Tables
-    - Playlists
-    - Compendiums
-    - Configuration
-- A default height and width can be set in the configuration menu for popouts
-- The size and position of popouts can be remembered in between session to maintain preferred layouts
+## Compatibility
 
-# Contact
+- Module version: `1.6.1`
+- Foundry minimum: `13`
+- Verified with Foundry: `14.362`
 
-If you have any questions about the module or troubles, feel free to create an issue here or send me a ping in the FoundryVTT discord channel @Cardagon
+This release keeps the original module behavior while making sidebar popout resizing work with Foundry's V13/V14 application rendering.
 
-# Updates
+## Features
 
-## 1.5 - 2023-07-24
-- Add support for V11
+- Adds resize support to Foundry sidebar popouts.
+- Supports default sidebar popout width and height settings.
+- Can remember sidebar popout size and position between sessions.
+- Keeps combat tracker scroll-to-turn behavior when reopening remembered combat popouts.
 
-## 1.4 - 2020-07-08
-- Add support for localization
-- Add support for german language
+## Changes
 
-## 1.1 - 2020-10-21
-- Confirmed support for Foundry Core 0.7.5
+### `1.6.1`
 
-## 1.0 - 2020-7-3
-- Added scroll to turn so that switching to next turn / previous turn does scroll to top for combat tracker
-- Changing remember last popout size to true by default
-- Stable release
+- Verified against Foundry `14.362`.
+- Updated compatibility metadata for Foundry V14 and removed the stale maximum-version cap.
+- Ported the useful V13/ApplicationV2 sidebar popout work from PR [#22](https://github.com/Cardagon/popout-resizer/pull/22), credited to iconmaster5326.
+- Added V14-aware `renderApplicationV2` handling for sidebar popouts.
+- Uses Foundry's current `foundry.applications.ux.Draggable` class when available.
+- Hardened resize setup for missing handles and repeated renders.
+- Fixed saved-size setting updates so stored dimensions remain an object.
 
-## 0.7 - 2020-6-25
-- Changed scripts to esmodules
-- Resolved issue where pin-cushion was grabbing wrong registerSettings method this has been resolved by using esmodules
+## Credits
 
-## 0.6 - 2020-6-23
-- Added configuration menu
-    - Default Width
-    - Default Height
-    - Remember Size and Position
-- Popouts will now be opened according to the default width and height set in configuration menu (set per user)
-- If the "Remember Size and Position" option is enabled popouts will now re-open to the same size and position they were last closed at
-    - This is remembered in between sessions
-    - This is per user
-- Cleaned up code and removed some redundancies 
-
-## 0.5 - 2020-6-22
-- Migrated repo to github from gitlab, no feature changes
-
-## 0.4 - 2020-6-19
-- Fixing error introduced in 0.3
-
-## 0.3 - 2020-6-19
-- Adding support for PF2E
-
-## 0.2 - 2020-6-18
-- Fixing bug that would remove re-sizing when ending turn, or changing turn on the combat tracker
-
-## 0.1 - 2020-6-16
-- Ability to re-size popouts from the side toolbar
+Popout Resizer was created by Cardagon. This release credits iconmaster5326 for the prior V13 sidebar popout work in PR [#22](https://github.com/Cardagon/popout-resizer/pull/22), which informed the V14 compatibility update here.

--- a/main.js
+++ b/main.js
@@ -1,15 +1,20 @@
-import * as PopoutSetings from './modules/register-settings.js';
-import * as PopoutResizer from './modules/popout-resizer.js';
+import * as PopoutSettings from "./modules/register-settings.js";
+import * as PopoutResizer from "./modules/popout-resizer.js";
 
-Hooks.on("init", async () => {
-    // Hook into all render sidebar tabs this will fire for every sidebar tab
-    Hooks.on("renderSidebarTab", PopoutResizer.PopoutResizer.sidebarTabRendered);
+Hooks.once("init", () => {
+  PopoutSettings.registerSettings();
+  PopoutSettings.initializeSettings();
 
-    // Handle combat tracker for PF2E
-    if(game.system.id === 'pf2e') {
-        Hooks.on('renderCombatTracker', PopoutResizer.PopoutResizer.sidebarTabRendered);
-    }
+  Hooks.on("renderSidebarTab", PopoutResizer.PopoutResizer.sidebarTabRendered);
+  Hooks.on(
+    "renderApplicationV2",
+    PopoutResizer.PopoutResizer.applicationV2Rendered,
+  );
 
-    PopoutSetings.registerSettings();
-    PopoutSetings.initializeSettings();
+  if (game.system?.id === "pf2e") {
+    Hooks.on(
+      "renderCombatTracker",
+      PopoutResizer.PopoutResizer.sidebarTabRendered,
+    );
+  }
 });

--- a/module.json
+++ b/module.json
@@ -1,35 +1,35 @@
 {
-	"id": "popout-resizer",
-	"name": "popout-resizer",
-	"title": "Popout Resizer",
-	"description": "A simple module that allows you to resize the side toolbar popouts such as the combat tracker, scenes, actors and compendiums.",
-	"version": "1.5.1",
-	"author": "cardagon",
-    "authors": [{ "name": "cardagon" }],
-	"compatibility": {
-	    "minimum": 9,
-    	"verified": "11.306",
-    	"maximum": "11"
-	},
-	"esmodules": [
-		"./main.js"
-	],
-	"styles": [
-		"./popout-resizer.css"
-	],
-	"url": "https://github.com/Cardagon/popout-resizer",
-	"download": "https://github.com/Cardagon/popout-resizer/releases/download/v1.5.1/v1.5.1.zip",
-	"manifest": "https://raw.githubusercontent.com/Cardagon/popout-resizer/master/module.json",
-	"languages": [
-		{
-			"lang": "en",
-			"name": "English",
-			"path": "lang/en.json"
-		},
-		{
-			"lang": "de",
-			"name": "Deutsch",
-			"path": "lang/de.json"
-		}
-	]
+  "id": "popout-resizer",
+  "name": "popout-resizer",
+  "title": "Popout Resizer",
+  "description": "A simple module that allows users to resize sidebar popouts such as combat, scenes, actors, journals, items, tables, playlists, compendiums, and configuration.",
+  "version": "1.6.1",
+  "author": "cardagon",
+  "authors": [
+    { "name": "cardagon" },
+    { "name": "iconmaster5326", "url": "https://github.com/iconmaster5326" }
+  ],
+  "compatibility": {
+    "minimum": "13",
+    "verified": "14.362"
+  },
+  "esmodules": ["./main.js"],
+  "styles": ["./popout-resizer.css"],
+  "readme": "https://github.com/Cardagon/popout-resizer#readme",
+  "url": "https://github.com/Cardagon/popout-resizer",
+  "download": "https://github.com/Cardagon/popout-resizer/releases/download/v1.6.1/module.zip",
+  "manifest": "https://raw.githubusercontent.com/Cardagon/popout-resizer/master/module.json",
+  "bugs": "https://github.com/Cardagon/popout-resizer/issues",
+  "languages": [
+    {
+      "lang": "en",
+      "name": "English",
+      "path": "lang/en.json"
+    },
+    {
+      "lang": "de",
+      "name": "Deutsch",
+      "path": "lang/de.json"
+    }
+  ]
 }

--- a/modules/constants.js
+++ b/modules/constants.js
@@ -1,0 +1,1 @@
+export const MODULE_ID = "popout-resizer";

--- a/modules/popout-resizer.js
+++ b/modules/popout-resizer.js
@@ -1,98 +1,217 @@
+import { MODULE_ID } from "./constants.js";
+
+const MINIMUM_SIZE = 200;
+
 /**
- * Static class that handles the sidebar tab rendered hook
+ * Static class that handles sidebar popout render hooks.
  */
 export class PopoutResizer {
+  static defaultWidth = 300;
+  static defaultHeight = 400;
+  static rememberSize = false;
+  static popoutResizerSettings = {};
+  static handledApps = new WeakSet();
 
-    static defaultWidth = 300;
-    static defaultHeight = 400;
-    static rememberSize = false;
-    static popoutResizerSettings = null;
+  static sidebarTabRendered(app, html) {
+    PopoutResizer.handleRenderedApp(app, html, true);
+  }
 
-    static sidebarTabRendered(obj, html, data) {
+  static applicationV2Rendered(app, html) {
+    PopoutResizer.handleRenderedApp(app, html);
+  }
 
-        // Only handle this event if the obj in question is a popout
-        if(obj.options.popOut){
+  static handleRenderedApp(app, html, allowLegacySidebar = false) {
+    const element = PopoutResizer.getElement(app, html);
+    if (
+      !app ||
+      !element ||
+      !PopoutResizer.isSidebarPopout(app, element, allowLegacySidebar)
+    )
+      return;
 
-            // Get existing size data
-            let resizeData = PopoutResizer.popoutResizerSettings[obj.tabName];
-            let resizeHandled = obj.resizeHandled;
+    PopoutResizer.popoutResizerSettings ??= {};
 
-            if(!resizeHandled){
-                var resizablePopout = new ResizablePopout(obj, html);
-            }
+    const appKey = PopoutResizer.getStorageKey(app);
+    const alreadyHandled =
+      PopoutResizer.handledApps.has(app) ||
+      element.dataset.popoutResizerHandled === "true";
 
-            // If we are supposed to remember size or if the popout is already open
-            if(resizeData && (resizeHandled || PopoutResizer.rememberSize)) {
-                obj.setPosition({left: resizeData.left, top: resizeData.top, width: resizeData.width, height: resizeData.height});
-                if(obj.tabName === 'combat') {
-                    obj.scrollToTurn();
-                }
-            } else {
-                obj.setPosition({width: PopoutResizer.defaultWidth, height: PopoutResizer.defaultHeight});
-            }
-        }
+    if (!alreadyHandled) {
+      new ResizablePopout(app, element, appKey);
+      PopoutResizer.handledApps.add(app);
+      element.dataset.popoutResizerHandled = "true";
     }
+
+    const resizeData = PopoutResizer.popoutResizerSettings[appKey];
+
+    if (resizeData && (alreadyHandled || PopoutResizer.rememberSize)) {
+      PopoutResizer.applyResizeData(app, resizeData);
+      if (PopoutResizer.isCombatTracker(app, appKey)) app.scrollToTurn?.();
+    } else if (!alreadyHandled) {
+      app.setPosition?.({
+        width: Math.max(PopoutResizer.defaultWidth, MINIMUM_SIZE),
+        height: Math.max(PopoutResizer.defaultHeight, MINIMUM_SIZE),
+      });
+    }
+  }
+
+  static getElement(app, html) {
+    const fromHtml = PopoutResizer.getFirstElement(html);
+
+    if (fromHtml) return fromHtml.closest?.(".app, .application") ?? fromHtml;
+
+    const appElement =
+      PopoutResizer.getFirstElement(app?.element) ??
+      PopoutResizer.getFirstElement(app?._element);
+
+    return appElement?.closest?.(".app, .application") ?? appElement;
+  }
+
+  static getFirstElement(value) {
+    if (!value) return null;
+    if (PopoutResizer.isHTMLElement(value)) return value;
+
+    const first = value[0];
+    if (PopoutResizer.isHTMLElement(first)) return first;
+
+    return null;
+  }
+
+  static isHTMLElement(value) {
+    const HTMLElementCtor = value?.ownerDocument?.defaultView?.HTMLElement;
+    return Boolean(HTMLElementCtor && value instanceof HTMLElementCtor);
+  }
+
+  static isSidebarPopout(app, element, allowLegacySidebar = false) {
+    if (element?.classList?.contains("sidebar-popout")) return true;
+    if (element?.closest?.(".sidebar-popout")) return true;
+
+    return Boolean(
+      allowLegacySidebar && app?.options?.popOut && (app.tabName || app.id),
+    );
+  }
+
+  static getStorageKey(app) {
+    return String(
+      app.tabName ||
+        app.id ||
+        app.options?.id ||
+        app.title ||
+        app.constructor?.name,
+    );
+  }
+
+  static isCombatTracker(app, appKey) {
+    return app.tabName === "combat" || appKey.toLowerCase().includes("combat");
+  }
+
+  static applyResizeData(app, resizeData) {
+    const position = {};
+
+    for (const property of ["left", "top", "width", "height"]) {
+      const rawValue = resizeData[property];
+      if (rawValue === null || rawValue === undefined) continue;
+
+      const value = Number(rawValue);
+      if (Number.isFinite(value)) position[property] = value;
+    }
+
+    if (Object.keys(position).length) app.setPosition?.(position);
+  }
+
+  static saveResizeData(appKey, resizeData) {
+    PopoutResizer.popoutResizerSettings = {
+      ...(PopoutResizer.popoutResizerSettings ?? {}),
+      [appKey]: resizeData,
+    };
+
+    const save = game.settings.set(
+      MODULE_ID,
+      "popout-resizer-settings",
+      PopoutResizer.popoutResizerSettings,
+    );
+
+    save?.catch?.((error) => {
+      console.warn("Popout Resizer | Failed to save popout size", error);
+    });
+  }
 }
 
 /**
- * Wrapper class for resizable popout
+ * Wrapper class for resizable popouts.
  */
 class ResizablePopout {
-    constructor(app, html) {
-        this.app = app;
-        this.html = html;
+  constructor(app, element, appKey) {
+    this.app = app;
+    this.element = element;
+    this.appKey = appKey;
+    this._onDragMouseUp = this._onDragMouseUp.bind(this);
+    this._onResizeMouseUp = this._onResizeMouseUp.bind(this);
 
-        const header = html.find('header')[0];
-        header.addEventListener('pointerdown', e => this._onDragMouseDown(e), false);
-        
-        this.dragHandler = new Draggable(app, html, header, true);
-        
-        this.handle = this.html.find('.window-resizable-handle')[0];
-        if(this.handle) {
-            this.handle.addEventListener('pointerdown', e => this._onResizeMouseDown(e), false);
-        } else {
-            console.error(game.i18n.format('POPOUTRESIZER.NoResizeHandlerError', {appId : this.app.id}));
-        }
+    const header = element.querySelector("header.window-header, header");
+    if (header) {
+      header.addEventListener(
+        "pointerdown",
+        (event) => this._onDragMouseDown(event),
+        false,
+      );
 
-        this.app.resizeHandled = true;
-        this.app.options.height = null;
+      const DraggableClass =
+        foundry?.applications?.ux?.Draggable ?? globalThis.Draggable;
+      if (DraggableClass) {
+        this.dragHandler = new DraggableClass(app, element, header, true);
+      }
     }
 
-    _onDragMouseDown(event) {
-        window.addEventListener('pointerup', e => this._onDragMouseUp(e), false);
+    this.handle = element.querySelector(".window-resizable-handle");
+    if (this.handle) {
+      this.handle.addEventListener(
+        "pointerdown",
+        (event) => this._onResizeMouseDown(event),
+        false,
+      );
+    } else {
+      console.warn(
+        game.i18n.format("POPOUTRESIZER.NoResizeHandlerError", {
+          appId: this.app.id,
+        }),
+      );
     }
 
-    _onDragMouseUp(event) {
-        window.removeEventListener('pointerup', e => this._onDragMouseUp(e), false);
+    if (this.app.options) this.app.options.height = null;
+  }
 
-        let resizeData = {
-            width: this.app.position.width, 
-            height: this.app.position.height, 
-            top: this.app.position.top, 
-            left: this.app.position.left
-        };
+  _onDragMouseDown(event) {
+    const eventWindow = event.view ?? window;
+    eventWindow.addEventListener("pointerup", this._onDragMouseUp, {
+      once: true,
+    });
+  }
 
-        PopoutResizer.popoutResizerSettings[this.app.tabName] = resizeData;
-        game.settings.set('popout-resizer', 'popout-resizer-settings', PopoutResizer.popoutResizerSettings);
-    }
+  _onDragMouseUp() {
+    this._saveCurrentPosition();
+  }
 
-    // Begin capturing mouse up events to record new window size
-    _onResizeMouseDown(event) {
-        window.addEventListener('pointerup', e => this._onResizeMouseUp(e), false);
-    }
+  _onResizeMouseDown(event) {
+    const eventWindow = event.view ?? window;
+    eventWindow.addEventListener("pointerup", this._onResizeMouseUp, {
+      once: true,
+    });
+  }
 
-    // On mouse up record window size as the resize event has ended
-    _onResizeMouseUp(event) {
-        window.removeEventListener('pointerup', e => this._onResizeMouseUp(e), false);
+  _onResizeMouseUp() {
+    this._saveCurrentPosition();
+  }
 
-        let resizeData = {
-            width: this.app.position.width, 
-            height: this.app.position.height, 
-            top: this.app.position.top, 
-            left: this.app.position.left
-        };
+  _saveCurrentPosition() {
+    const position = this.app.position ?? {};
+    const resizeData = {
+      width: position.width,
+      height: position.height,
+      top: position.top,
+      left: position.left,
+    };
 
-        PopoutResizer.popoutResizerSettings[this.app.tabName] = resizeData;
-        game.settings.set('popout-resizer', 'popout-resizer-settings', PopoutResizer.popoutResizerSettings);
-    }
+    PopoutResizer.saveResizeData(this.appKey, resizeData);
+  }
 }

--- a/modules/register-settings.js
+++ b/modules/register-settings.js
@@ -1,64 +1,58 @@
-import { PopoutResizer } from './popout-resizer.js';
+import { MODULE_ID } from "./constants.js";
+import { PopoutResizer } from "./popout-resizer.js";
 
 export function registerSettings() {
+  game.settings.register(MODULE_ID, "defaultWidth", {
+    name: game.i18n.localize("POPOUTRESIZER.DefaultWidth.Name"),
+    hint: game.i18n.localize("POPOUTRESIZER.DefaultWidth.Hint"),
+    scope: "client",
+    config: true,
+    type: Number,
+    default: 300,
+    onChange: (value) => {
+      PopoutResizer.defaultWidth = value;
+    },
+  });
 
-    /* Default Popout Width */
-    game.settings.register('popout-resizer', 'defaultWidth', {
-        name: game.i18n.localize('POPOUTRESIZER.DefaultWidth.Name'),
-        hint: game.i18n.localize('POPOUTRESIZER.DefaultWidth.Hint'),
-        scope: 'client',
-        config: true,
-        type: Number,
-        default: 300,
-        onChange: value => {
-            PopoutResizer.defaultWidth = value;
-        }
-    });
+  game.settings.register(MODULE_ID, "defaultHeight", {
+    name: game.i18n.localize("POPOUTRESIZER.DefaultHeight.Name"),
+    hint: game.i18n.localize("POPOUTRESIZER.DefaultHeight.Hint"),
+    scope: "client",
+    config: true,
+    type: Number,
+    default: 400,
+    onChange: (value) => {
+      PopoutResizer.defaultHeight = value;
+    },
+  });
 
-    /* Default Popout Height */
-    game.settings.register('popout-resizer', 'defaultHeight', {
-        name: game.i18n.localize('POPOUTRESIZER.DefaultHeight.Name'),
-        hint: game.i18n.localize('POPOUTRESIZER.DefaultHeight.Hint'),
-        scope: 'client',
-        config: true,
-        type: Number,
-        default: 400,
-        onChange: value => {
-            PopoutResizer.defaultHeight = value;
-        }
-    });
-    
-    /* Enable/Disable Saving Popout Size and Position */
-    game.settings.register('popout-resizer', 'rememberSize', {
-        name: game.i18n.localize('POPOUTRESIZER.RememberSize.Name'),
-        hint: game.i18n.localize('POPOUTRESIZER.RememberSize.Hint'),
-        scope: 'client',
-        config: true,
-        type: Boolean,
-        default: true,
-        onChange: value => {
-            PopoutResizer.rememberSize = value;
-        }
-    });
+  game.settings.register(MODULE_ID, "rememberSize", {
+    name: game.i18n.localize("POPOUTRESIZER.RememberSize.Name"),
+    hint: game.i18n.localize("POPOUTRESIZER.RememberSize.Hint"),
+    scope: "client",
+    config: true,
+    type: Boolean,
+    default: true,
+    onChange: (value) => {
+      PopoutResizer.rememberSize = value;
+    },
+  });
 
-    /* Saved Popout Sizes and Positions */
-    game.settings.register('popout-resizer', 'popout-resizer-settings', {
-        scope: 'client',
-        config: false,
-        type: Object,
-        default: new Object(),
-        onChange: value => {
-            PopoutResizer.rememberSize = value;
-        }
-    });
-
+  game.settings.register(MODULE_ID, "popout-resizer-settings", {
+    scope: "client",
+    config: false,
+    type: Object,
+    default: {},
+    onChange: (value) => {
+      PopoutResizer.popoutResizerSettings = value ?? {};
+    },
+  });
 }
 
 export function initializeSettings() {
-    PopoutResizer.defaultWidth = game.settings.get('popout-resizer', 'defaultWidth');
-    PopoutResizer.defaultHeight = game.settings.get('popout-resizer', 'defaultHeight');
-    
-    PopoutResizer.rememberSize = game.settings.get('popout-resizer', 'rememberSize');
-
-    PopoutResizer.popoutResizerSettings = game.settings.get('popout-resizer', 'popout-resizer-settings');
+  PopoutResizer.defaultWidth = game.settings.get(MODULE_ID, "defaultWidth");
+  PopoutResizer.defaultHeight = game.settings.get(MODULE_ID, "defaultHeight");
+  PopoutResizer.rememberSize = game.settings.get(MODULE_ID, "rememberSize");
+  PopoutResizer.popoutResizerSettings =
+    game.settings.get(MODULE_ID, "popout-resizer-settings") ?? {};
 }

--- a/popout-resizer.css
+++ b/popout-resizer.css
@@ -1,3 +1,9 @@
-.app.sidebar-popout {
-    min-height: 200px;
+.sidebar-popout {
+  min-height: 200px;
+  min-width: 200px;
+}
+
+.sidebar-popout .window-resizable-handle {
+  display: grid;
+  justify-items: end;
 }


### PR DESCRIPTION
## Summary

This updates Popout Resizer for Foundry V14 while preserving the original module id and user-facing behavior.

Changes included:
- verify compatibility through Foundry `14.362` and remove the stale maximum-version cap
- update module metadata and README for an upstream `1.6.1` release
- port the useful V13/ApplicationV2 sidebar popout work from PR #22, credited to iconmaster5326
- add `renderApplicationV2` handling for Foundry V13/V14 sidebar popouts
- detect sidebar popouts through `.sidebar-popout` instead of relying only on old V1 sidebar assumptions
- use `foundry.applications.ux.Draggable` when available
- guard repeated renders, missing resize handles, and saved-size object updates
- keep the 200px minimum popout size styling and resize-handle display fix
- modernize the release workflow to publish `module.json` and `module.zip` assets matching the manifest download URL

## Validation

- Installed and tested locally in Foundry `14.362` with D35E `3.0.2`
- User testing confirmed PopOut! and Popout Resizer are working together before opening this PR
- `node --check main.js`
- `node --check modules/popout-resizer.js`
- `node --check modules/register-settings.js`
- manifest/reference validation for scripts, styles, language files, README, upstream URLs, and compatibility metadata
- package-shape check with `module.json`, `main.js`, `modules/`, `popout-resizer.css`, `lang/`, and `README.md` at zip root
- local security gate on changed files: `0 errors`, `0 warnings`

A public fork release used for install testing is available at:
https://github.com/SpencerZPoole/popout-resizer/releases/tag/v1.6.1
